### PR TITLE
Update subscribe.lua

### DIFF
--- a/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
+++ b/luci-app-ssr-plus/root/usr/share/shadowsocksr/subscribe.lua
@@ -364,6 +364,7 @@ local function processData(szType, content)
 		result.packet_encoding = packet_encoding
 		result.tls = (params.security == "tls") and "1" or "0"
 		result.tls_host = params.sni
+		result.tls_flow = params.flow
 		result.xtls = params.security == "xtls" and "1" or nil
 		result.vless_flow = params.flow
 		result.fingerprint = params.fp


### PR DESCRIPTION
当订阅vless时，如果使用了新流控，security 应该为`tls`，然而并没有设置对应的 `tls_flow`。因此生成 config 的时候会丢失 `flow`
